### PR TITLE
이제 pypi에서 제대로 결과를 찾습니다.

### DIFF
--- a/lambdas/ARMCompatibilityBot_lambda/src/analyze_tools/dependency_tools/python/pypi_api.py
+++ b/lambdas/ARMCompatibilityBot_lambda/src/analyze_tools/dependency_tools/python/pypi_api.py
@@ -1,8 +1,12 @@
-import re
+import json
 import logging
 import requests
-from typing import Optional, Dict, Any
-from config import GITHUB_TOKEN  # GITHUB_TOKEN을 config.py에서 관리한다고 가정
+from typing import Optional, Dict, Any, List
+
+# Correct import for recent packaging versions
+from packaging.utils import canonicalize_name
+from packaging.version import parse as parse_version, InvalidVersion
+from packaging.specifiers import SpecifierSet, InvalidSpecifier
 
 # Configure logger
 logging.basicConfig(level=logging.INFO)
@@ -12,158 +16,375 @@ logger = logging.getLogger(__name__)
 PYPI_CACHE = {}
 
 
-def check_pypi_package_arm_compatibility(package_name, package_version=None):
+def check_pypi_package_arm_compatibility(
+    package_name: str, package_version_specifier: Optional[str] = None
+) -> Dict[str, Any]:
     """
-    Check if a PyPI package is compatible with ARM64 architecture.
-    Uses PyPI API to check for ARM64 wheel availability or universal compatibility.
+    Check if a PyPI package, potentially with a version specifier, is compatible
+    with ARM64 architecture. Uses PyPI API and the packaging library.
 
     Args:
-        package_name (str): Name of the package (e.g., "pybloomfiltermmap3" or "numpy>=1.20").
-        package_version (str, optional): Specific version to check (e.g., "0.6.0").
+        package_name (str): Name of the package (e.g., "tensorflow_datasets").
+        package_version_specifier (str, optional): Version constraint
+            (e.g., "==1.2.3", ">=1.20", "<=2.0,>1.0"). Defaults to None (latest).
 
     Returns:
-        dict: {"compatible": bool or "partial" or "unknown", "reason": str}
+        dict: {"compatible": bool or "partial" or "unknown", "reason": str,
+               "checked_version": str or None}
     """
-    cache_key = f"{package_name}@{package_version}" if package_version else package_name
+    try:
+        # 1. Canonicalize package name (e.g., tensorflow_datasets -> tensorflow-datasets)
+        # Use canonicalize_name instead of normalize_name
+        normalized_name = canonicalize_name(package_name)
+    except Exception as e:  # Catch potential errors in canonicalization itself
+        logger.error(f"Error canonicalizing package name '{package_name}': {e}")
+        return {
+            "compatible": "unknown",
+            "reason": f"Invalid package name format: {package_name}",
+            "checked_version": None,
+        }
+
+    # 2. Create cache key using canonicalized name and specifier
+    cache_key = (
+        f"{normalized_name}@{package_version_specifier}"
+        if package_version_specifier
+        else normalized_name
+    )
     if cache_key in PYPI_CACHE:
+        logger.debug(f"Using cached result for {cache_key}")
         return PYPI_CACHE[cache_key]
 
+    logger.info(
+        f"Checking PyPI compatibility for: {normalized_name}"
+        f"{'@' + package_version_specifier if package_version_specifier else ' (latest)'}"
+    )
+
     try:
+        # 3. Fetch package data from PyPI JSON API (always fetch base URL for all versions)
+        url = f"https://pypi.org/pypi/{normalized_name}/json"
+        response = requests.get(url, timeout=10)  # Increased timeout slightly
 
-        # 패키지 이름 정리
-        package_name = package_name.strip().lower()
-        clean_name = re.sub(r"[=<>!~].*$", "", package_name)  # 버전 지정자 제거
-
-        # PyPI JSON API 호출
-        url = f"https://pypi.org/pypi/{clean_name}/json"
-        if package_version:
-            url = f"https://pypi.org/pypi/{clean_name}/{package_version}/json"
-
-        response = requests.get(url, timeout=5)
-
-        if response.status_code != 200:
-            logger.warning(
-                f"Failed to fetch package info for {clean_name}: HTTP {response.status_code}"
+        if response.status_code == 404:
+            logger.warning(f"Package {normalized_name} not found on PyPI.")
+            # Cache the "not found" result to avoid repeated checks
+            result_not_found = {
+                "compatible": "unknown",
+                "reason": f"Package '{normalized_name}' not found on PyPI.",
+                "checked_version": None,
+            }
+            PYPI_CACHE[cache_key] = result_not_found
+            return result_not_found
+        elif response.status_code != 200:
+            logger.error(
+                f"Failed to fetch package info for {normalized_name}: HTTP {response.status_code}"
             )
+            # Don't cache transient API errors as aggressively? Or cache with short TTL?
+            # For now, return without caching.
             return {
                 "compatible": "unknown",
-                "reason": f"Package not found or PyPI API error: {response.status_code}",
+                "reason": f"PyPI API error for '{normalized_name}': HTTP {response.status_code}",
+                "checked_version": None,
             }
 
         data = response.json()
+        available_versions_str = list(data.get("releases", {}).keys())
 
-        # 특정 버전 확인 또는 최신 버전 사용
-        if package_version:
-            if package_version not in data["releases"]:
+        # 4. Determine the target version to check
+        target_version_str: Optional[str] = None
+        specifier_set: Optional[SpecifierSet] = None
+
+        if package_version_specifier:
+            try:
+                # Allow comma-separated specifiers like "<=2.0,>1.0"
+                specifier_set = SpecifierSet(package_version_specifier)
+            except InvalidSpecifier:
+                logger.error(
+                    f"Invalid version specifier '{package_version_specifier}' for {normalized_name}"
+                )
+                result_invalid_spec = {
+                    "compatible": "unknown",
+                    "reason": f"Invalid version specifier: '{package_version_specifier}'",
+                    "checked_version": None,
+                }
+                PYPI_CACHE[cache_key] = result_invalid_spec  # Cache invalid spec result
+                return result_invalid_spec
+
+            # Find the latest available version that satisfies the specifier
+            latest_satisfying_version = None
+            candidate_versions = []
+            for v_str in available_versions_str:
+                try:
+                    parsed_v = parse_version(v_str)
+                    # Store valid versions for filtering
+                    candidate_versions.append(parsed_v)
+                except InvalidVersion:
+                    logger.warning(
+                        f"Skipping invalid version format '{v_str}' for {normalized_name}"
+                    )
+                    continue  # Skip versions we can't parse
+
+            # Filter using the specifier set. Include prereleases if the specifier allows them.
+            # The `prereleases` flag in `filter` depends on whether the specifier itself includes a pre-release marker (e.g., >=1.0.0rc1)
+            # We might need to explicitly allow pre-releases if the specifier doesn't contain one but we want to consider them.
+            # For simplicity here, let's assume standard filtering works for most cases.
+            # If you need fine-grained pre-release control, add a flag or check specifier details.
+            allowed_versions = list(
+                specifier_set.filter(candidate_versions, prereleases=True)
+            )
+
+            if allowed_versions:
+                # Find the maximum version among the allowed ones
+                target_version_str = str(max(allowed_versions))
+                logger.info(
+                    f"Found latest version satisfying '{package_version_specifier}': {target_version_str}"
+                )
+            else:
+                logger.warning(
+                    f"No available version of {normalized_name} satisfies specifier '{package_version_specifier}'"
+                )
+                available_preview = available_versions_str[
+                    -5:
+                ]  # Show some recent available
+                result_no_satisfy = {
+                    "compatible": "unknown",
+                    "reason": f"No version found satisfying '{package_version_specifier}'. "
+                    f"Latest available: {', '.join(available_preview)}...",
+                    "checked_version": None,
+                }
+                PYPI_CACHE[cache_key] = (
+                    result_no_satisfy  # Cache unsatisfiable spec result
+                )
+                return result_no_satisfy
+        else:
+            # No specifier provided, use the latest stable version reported by PyPI
+            target_version_str = data.get("info", {}).get("version")
+            if not target_version_str:
+                logger.error(
+                    f"Could not determine latest version for {normalized_name}"
+                )
+                # Don't cache if PyPI info is broken
                 return {
                     "compatible": "unknown",
-                    "reason": f"Version {package_version} not found",
+                    "reason": "Could not determine latest version from PyPI info.",
+                    "checked_version": None,
                 }
-            releases = data["releases"][package_version]
-        else:
-            # 최신 버전 사용 (urls 필드가 현재 버전의 배포 파일 정보를 담고 있음)
-            releases = data["urls"]
+            logger.info(f"Using latest reported version: {target_version_str}")
 
-        # 플랫폼 호환성 확인 개선
+        # 5. Analyze the release files for the target version
+        if target_version_str not in data.get("releases", {}):
+            logger.error(
+                f"Target version {target_version_str} not found in releases dict for {normalized_name}"
+            )
+            # This might happen if info.version points to a pre-release not in the main list sometimes?
+            # Or if specifier logic selected a version that's somehow missing.
+            # Don't cache this internal inconsistency state
+            return {
+                "compatible": "unknown",
+                "reason": f"Internal error: Target version {target_version_str} details missing.",
+                "checked_version": target_version_str,
+            }
+
+        release_files = data["releases"].get(target_version_str, [])
+        # Get info specific to the target version if available, otherwise use main info
+        version_specific_info = (
+            data.get("releases", {}).get(target_version_str, [{}])[0]
+            if release_files
+            else {}
+        )
+        info_for_version = data.get(
+            "info", {}
+        )  # Use main info block for classifiers etc.
+
+        # Check if the target version itself is yanked
+        yanked = version_specific_info.get("yanked", False) or any(
+            f.get("yanked", False) for f in release_files
+        )
+        yanked_reason = version_specific_info.get("yanked_reason")
+        if yanked and not yanked_reason:
+            # Find the reason from the first yanked file (usually the same for all files in a yanked release)
+            for f in release_files:
+                if f.get("yanked", False):
+                    yanked_reason = f.get("yanked_reason", "No reason provided")
+                    break
+        if yanked:
+            logger.warning(
+                f"Version {target_version_str} of {normalized_name} is yanked: {yanked_reason}"
+            )
+
+        # 6. Check for compatible wheels or source distributions
         arm_wheels = []
         universal_wheels = []
         sdist_files = []
+        other_arch_wheels = []  # e.g., x86_64
 
-        for release in releases:
+        for release in release_files:
+            # Skip yanked files unless we specifically want to analyze them
+            if release.get("yanked", False):
+                continue
+
             filename = release.get("filename", "")
             packagetype = release.get("packagetype", "")
+            py_version_tag = release.get("python_version", "")  # e.g., 'cp39'
 
-            # 휠 파일 확인
             if packagetype == "bdist_wheel":
-                # 파일명에서 플랫폼 태그 추출
-                platform_tag = (
-                    filename.rsplit("-", 1)[1].split(".whl")[0]
-                    if ".whl" in filename
-                    else ""
-                )
+                # Simple platform tag extraction (might need refinement for complex tags)
+                parts = filename.rsplit("-", 3)  # try splitting by last 3 hyphens
+                if len(parts) >= 3 and ".whl" in parts[-1]:
+                    # platform_tag = parts[-1].split(".whl")[0]
+                    # More robust: Look for known arch tags within the last part
+                    wheel_tags = parts[-1].split(".whl")[
+                        0
+                    ]  # e.g., cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64
+                    platform_tag_found = False
 
-                # ARM 호환 휠 확인
-                if any(
-                    arm_id in platform_tag.lower()
-                    for arm_id in ["aarch64", "arm64", "armv8", "armv7l"]
-                ):
-                    arm_wheels.append(filename)
-                # 범용 휠 확인
-                elif platform_tag == "any" or "none-any" in platform_tag:
-                    universal_wheels.append(filename)
+                    # Check specific ARM tags
+                    if any(arm_id in wheel_tags for arm_id in ["aarch64", "arm64"]):
+                        arm_wheels.append(filename)
+                        platform_tag_found = True
+                    # Check x86 tags
+                    elif any(
+                        x86_id in wheel_tags
+                        for x86_id in ["win_amd64", "amd64", "x86_64", "x64"]
+                    ):
+                        other_arch_wheels.append(filename)
+                        platform_tag_found = True
+                    # Check universal tags AFTER specific ones
+                    elif not platform_tag_found and any(
+                        universal_id in wheel_tags
+                        for universal_id in ["any", "universal2"]
+                    ):
+                        # Special case: universal2 on macos is good
+                        if "universal2" in wheel_tags and "macosx" in wheel_tags:
+                            arm_wheels.append(
+                                filename
+                            )  # Treat macos universal2 as ARM compatible
+                        # Only count 'any' if it's not specifically for another arch (e.g. win_any - unlikely but possible)
+                        elif "any" in wheel_tags and not any(
+                            arch in wheel_tags for arch in ["win", "linux", "macosx"]
+                        ):
+                            universal_wheels.append(filename)
+                        platform_tag_found = True
+                    # Add more specific checks if needed (e.g., armv7l)
 
-            # 소스 배포판 확인
             elif packagetype == "sdist":
                 sdist_files.append(filename)
 
-        # requires_python 필드 확인
-        requires_python = data["info"].get("requires_python", "")
-
-        # 플랫폼 필드 확인 (null이면 플랫폼 독립적)
-        platform = data["info"].get("platform")
-        is_platform_independent = platform is None or platform == ""
-
-        # 결과 결정
+        # 7. Determine compatibility based on findings (considering only non-yanked files)
+        result = {}
         if arm_wheels:
             result = {
                 "compatible": True,
-                "reason": f"ARM-specific wheels available: {', '.join(arm_wheels)}",
+                "reason": f"ARM-specific wheels found for version {target_version_str}.",
+                # "details": f"Files: {', '.join(arm_wheels)}" # Optional: add detail
             }
         elif universal_wheels:
             result = {
                 "compatible": True,
-                "reason": f"Universal wheels available: {', '.join(universal_wheels)}",
-            }
-        elif sdist_files and is_platform_independent:
-            result = {
-                "compatible": True,
-                "reason": f"Platform-independent source distribution available: {', '.join(sdist_files)}",
+                "reason": f"Platform-agnostic wheels ('any') found for version {target_version_str}.",
             }
         elif sdist_files:
-            # 확장 모듈이 있는지 확인하기 위한 분류자 검사
-            classifiers = data["info"].get("classifiers", [])
-            has_c_extension = any("Programming Language :: C" in c for c in classifiers)
+            # Source distribution available, check if it likely needs compilation
+            classifiers = info_for_version.get("classifiers", [])
+            has_c_extension = any(
+                "Programming Language :: C" in c for c in classifiers
+            ) or any("Programming Language :: C++" in c for c in classifiers)
             has_cython = any("Programming Language :: Cython" in c for c in classifiers)
+            # Check platform markers more carefully if available
+            platform_info = info_for_version.get("platform")
+            is_platform_specific = (
+                platform_info not in [None, "", "any"] and platform_info
+            )  # Check if not None/empty/any
 
-            if has_c_extension or has_cython:
+            if has_c_extension or has_cython or is_platform_specific:
                 result = {
                     "compatible": "partial",
-                    "reason": "Source distribution with C/Cython extensions may require compilation",
+                    "reason": f"Source distribution found for {target_version_str}, but it may require compilation on ARM64 (contains C/C++/Cython or platform markers: '{platform_info}').",
                 }
             else:
+                # Pure Python sdist
                 result = {
                     "compatible": True,
-                    "reason": "Pure Python source distribution, likely compatible",
+                    "reason": f"Likely pure Python source distribution found for {target_version_str}.",
                 }
-        else:
+        elif other_arch_wheels:
+            # Only non-ARM wheels found
             result = {
                 "compatible": False,
-                "reason": "No compatible wheels or source distribution available",
+                "reason": f"Only non-ARM wheels (e.g., x86_64) found for non-yanked files of version {target_version_str}.",
+            }
+        else:
+            # No wheels, no sdist - potentially an issue with PyPI data or package structure, or only yanked files exist
+            result = {
+                "compatible": (
+                    False if not yanked else "unknown"
+                ),  # If yanked, status is more uncertain
+                "reason": f"No non-yanked wheels or source distribution found for version {target_version_str} on PyPI.",
             }
 
-        # 패키지가 yanked(철회)되었는지 확인
-        if data["info"].get("yanked", False):
-            yanked_reason = data["info"].get("yanked_reason", "No reason provided")
-            result["warning"] = f"Package version has been yanked: {yanked_reason}"
+        # Add yanked warning if applicable, even if compatibility was determined
+        if yanked:
+            result["warning"] = (
+                f"Version {target_version_str} has been yanked: {yanked_reason}"
+            )
+            logger.info(
+                f"Added yanked warning for {normalized_name} {target_version_str}: {result}"
+            )  # Add this log
 
-        # 캐싱
+        result["checked_version"] = target_version_str
+
+        # Cache the final result
         PYPI_CACHE[cache_key] = result
+        logger.debug(
+            f"Final result being returned for {cache_key}: {result}"
+        )  # Add this log
         return result
 
-    except Exception as e:
-        logger.error(f"Error checking {package_name}: {str(e)}")
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Network error checking {normalized_name}: {e}")
+        # Don't cache network errors
         return {
             "compatible": "unknown",
-            "reason": f"Error checking compatibility: {str(e)}",
+            "reason": f"Network error checking PyPI: {e}",
+            "checked_version": None,
+        }
+    except Exception as e:
+        logger.exception(
+            f"Unexpected error checking {normalized_name}@{package_version_specifier or 'latest'}: {e}"
+        )
+        # Don't cache unexpected errors
+        return {
+            "compatible": "unknown",
+            "reason": f"Unexpected error during compatibility check: {e}",
+            "checked_version": None,
         }
 
 
-# 예시 사용
+# --- Example Usage ---
 if __name__ == "__main__":
-    # pybloomfiltermmap3 최신 버전 확인
-    result = check_pypi_package_arm_compatibility("rbloom")
-    print(result)
+    # Test cases
+    packages_to_check = [
+        ("requests", None),
+        ("tensorflow_datasets", None),  # Underscore name
+        ("numpy", ">=1.20,<1.22"),  # Range specifier
+        ("numpy", "==1.21.0"),  # Exact version
+        ("pandas", "<=1.4"),  # Upper bound
+        ("cryptography", ">=35"),  # Lower bound (will likely find ARM wheels)
+        ("pybloomfiltermmap3", "==0.6.0"),  # Specific old version (likely no ARM wheel)
+        ("pybloom-live", None),  # Hyphen name
+        ("nonexistent_package_xyz", None),  # 404 test
+        ("numpy", "==99.0.0"),  # Version not satisfying
+        ("oslo.utils", ">=6.0.0,<6.1.0"),  # Period in name, range
+        ("elasticsearch", "==7.13.2"),  # Yanked version example
+        ("protobuf", "<3.20"),  # Example with potential C++ extension sdist
+    ]
 
-    # 특정 버전 확인
-    result = check_pypi_package_arm_compatibility("pybloomfiltermmap3", "0.6.0")
-    print(result)
+    for name, spec in packages_to_check:
+        print(f"\n--- Checking: {name} {spec or '(latest)'} ---")
+        result = check_pypi_package_arm_compatibility(name, spec)
+        print(json.dumps(result, indent=2))
+
+    # Example of clearing cache for re-testing
+    # PYPI_CACHE.clear()
+    # print("\n--- Checking numpy >=1.20,<1.22 after cache clear ---")
+    # result = check_pypi_package_arm_compatibility("numpy", ">=1.20,<1.22")
+    # print(json.dumps(result, indent=2))

--- a/lambdas/ARMCompatibilityBot_lambda/src/analyze_tools/dependency_tools/python/python_package_compatibility.py
+++ b/lambdas/ARMCompatibilityBot_lambda/src/analyze_tools/dependency_tools/python/python_package_compatibility.py
@@ -13,10 +13,10 @@ Python 언어 호환성 체커 구현
    - 테스트 실패: 대체 패키지 검색
    - 테스트 결과 없음: AWS ARM 환경 컴파일 제안
 
-3. 소스 컴파일 시도 (Case A) function: try_source_compilation
+3. 소스 컴파일 시도 (Case A) function: try_source_compilation - 제거됨
    - 소스 코드를 직접 컴파일하여 ARM 호환성 확인
 
-4. 대체 패키지 검색 (Case C) function: find_alternative_package
+4. 대체 패키지 검색 (Case C) function: find_alternative_package - 미구현
    - 호환성 문제가 있는 경우 ARM 지원 대체 패키지 제안 (현재 대체 패키지 없음)
 
 """
@@ -28,13 +28,16 @@ import sys
 import tempfile
 import logging
 from typing import Dict, Any, Optional, Union
+
+# 경로 수정: wheel_test_api -> .wheel_test_api (상대 경로)
 from .wheel_test_api import get_latest_wheel_tester_results
+
+# 경로 수정: pypi_api -> .pypi_api (상대 경로)
 from .pypi_api import check_pypi_package_arm_compatibility
 
 # Configure logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
 
 
 def check_python_package_compatibility(
@@ -46,34 +49,34 @@ def check_python_package_compatibility(
 ) -> Dict[str, Any]:
     """
     패키지의 ARM 호환성을 검사합니다. PyPI API와 wheel tester 결과를 사용합니다.
+    PyPI 결과에 warning이 있으면 reason에 포함시킵니다.
     """
-    clean_name = package_name.lower().replace("-", "_")  # 패키지 이름 정리
+    # 패키지 이름 정리 (정규화는 pypi_api에서 처리)
+    clean_name = package_name.lower().replace(
+        "_", "-"
+    )  # API 호출 전에 정규화된 이름 필요
     debug_info = {
         "pypi_check": None,
         "wheel_tester_check": None,
     }
     final_compatibility: Union[bool, str] = "unknown"
     final_reason = "Compatibility status could not be determined."
+    pypi_warning = None  # PyPI 경고를 저장할 변수
 
     # --- 1단계: PyPI API 확인 ---
     try:
-        pypi_result = check_pypi_package_arm_compatibility(clean_name, version_spec)
+        # API 호출 시 정제되지 않은 package_name과 version_spec 전달
+        pypi_result = check_pypi_package_arm_compatibility(package_name, version_spec)
         debug_info["pypi_check"] = pypi_result
-        logger.info(f"[{clean_name}] PyPI Check: {pypi_result}")
+        logger.info(f"[{package_name}] PyPI Check: {pypi_result}")
+
+        # 경고 저장
+        pypi_warning = pypi_result.get("warning")
 
         if pypi_result.get("compatible") is True:
             final_compatibility = True
             final_reason = pypi_result.get("reason", "Compatible according to PyPI.")
-            return {
-                "dependency": original_line or clean_name,
-                "name": clean_name,
-                "version_spec": version_spec,
-                "compatible": final_compatibility,
-                "reason": final_reason,
-                "direct": direct,
-                "parent": parent,
-                "debug_info": debug_info,
-            }
+            # 여기서 바로 반환하지 않고, wheel tester 결과도 확인하도록 변경
         elif pypi_result.get("compatible") is False:
             final_compatibility = False
             final_reason = pypi_result.get("reason", "Incompatible according to PyPI.")
@@ -82,85 +85,108 @@ def check_python_package_compatibility(
             final_reason = pypi_result.get(
                 "reason", "Partially compatible or requires build (PyPI)."
             )
-        else:
+        else:  # unknown
             final_compatibility = "unknown"
             final_reason = pypi_result.get("reason", "Compatibility unknown (PyPI).")
 
     except Exception as e:
-        logger.error(f"[{clean_name}] PyPI check failed: {e}")
+        logger.error(f"[{package_name}] PyPI check failed: {e}")
         debug_info["pypi_check"] = {"error": str(e)}
+        # PyPI 실패 시에도 wheel tester는 시도
 
     # --- 2단계: Arm64 Wheel Tester 결과 확인 ---
+    # Wheel Tester는 정규화된 이름 사용
+    normalized_name_for_tester = clean_name  # 이미 위에서 정규화된 이름 사용
     wheel_tester_results_data = get_latest_wheel_tester_results()
     if wheel_tester_results_data:
-        if clean_name in wheel_tester_results_data:
-            package_test_info = wheel_tester_results_data[clean_name]
+        if normalized_name_for_tester in wheel_tester_results_data:
+            package_test_info = wheel_tester_results_data[normalized_name_for_tester]
             debug_info["wheel_tester_check"] = {
                 "status": "found",
                 "tests": list(package_test_info.keys()),
             }
-            logger.info(f"[{clean_name}] Found in Wheel Tester results.")
+            logger.info(
+                f"[{normalized_name_for_tester}] Found in Wheel Tester results."
+            )
 
             passed_on_recent_ubuntu = False
             failed_tests = []
             build_required_somewhere = False
 
+            # 최신 Ubuntu 버전부터 확인 (noble -> jammy -> focal)
             for test_env in ["noble", "jammy", "focal"]:
                 if test_env in package_test_info:
                     test_result = package_test_info[test_env]
                     if test_result.get("test-passed") is True:
                         passed_on_recent_ubuntu = True
+                        # Wheel tester 통과 시, PyPI 결과가 어떻든 compatible로 간주하고 이유 업데이트
+                        final_compatibility = True
                         final_reason = f"Passed on {test_env} in Wheel Tester."
+                        if test_result.get("build-required") is True:
+                            final_reason += " (Build was required)."
+                        # 통과하면 더 이상 다른 환경 체크 불필요
                         break
                     else:
-                        failed_tests.append(test_env)
+                        # 실패한 테스트 기록 (가장 최근 실패를 우선)
+                        if not failed_tests:
+                            failed_tests.append(test_env)
                     if test_result.get("build-required") is True:
                         build_required_somewhere = True
 
-            if passed_on_recent_ubuntu:
-                final_compatibility = True
-                if build_required_somewhere:
-                    final_reason += (
-                        " (Note: build might be required on some platforms)."
-                    )
-            elif failed_tests:
-                if final_compatibility in ["unknown", "partial"]:
+            # 만약 모든 최신 환경에서 실패했다면
+            if not passed_on_recent_ubuntu and failed_tests:
+                failed_env = failed_tests[0]  # 가장 최근 실패 환경
+                # PyPI 결과가 True나 partial이 아니었다면, Wheel Tester 실패를 이유로 업데이트
+                if final_compatibility not in [True, "partial"]:
                     final_compatibility = False
-                    final_reason = f"Failed on {', '.join(failed_tests)} in Wheel Tester. {pypi_result.get('reason', '')}"
-                elif final_compatibility is False:
+                    final_reason = f"Failed on {failed_env} in Wheel Tester."
+                # PyPI 결과가 partial 이었다면, 실패 정보를 추가
+                elif final_compatibility == "partial":
                     final_reason += (
-                        f" Also failed on {', '.join(failed_tests)} in Wheel Tester."
+                        f" Additionally, failed on {failed_env} in Wheel Tester."
                     )
-        else:
-            logger.info(f"[{clean_name}] Not found in Wheel Tester results.")
-            debug_info["wheel_tester_check"] = {"status": "not_found"}
-    else:
-        logger.warning(f"[{clean_name}] Could not fetch Wheel Tester results.")
-        debug_info["wheel_tester_check"] = {"status": "fetch_error"}
+                # PyPI 결과가 False 였다면, 실패 정보를 추가
+                elif final_compatibility is False:
+                    final_reason += f" Also failed on {failed_env} in Wheel Tester."
 
-    # 3. 소스 컴파일 시도 - 제거!
-    # source_compilation_result = try_source_compilation(package_name, version_spec)
-    # debug_info["source_compilation"] = source_compilation_result
-    # if source_compilation_result.get("compatible") == True:
-    #     # This part is removed
-    #     pass
+            # 만약 Wheel Tester에서 통과했지만, PyPI에서 빌드 필요했다는 정보가 있었다면?
+            # -> Wheel Tester 통과를 더 우선시하므로 final_reason은 이미 업데이트됨.
+
+        else:
+            logger.info(
+                f"[{normalized_name_for_tester}] Not found in Wheel Tester results."
+            )
+            debug_info["wheel_tester_check"] = {"status": "not_found"}
+            # Wheel Tester 결과 없으면 PyPI 결과가 최종
+    else:
+        logger.warning(
+            f"[{normalized_name_for_tester}] Could not fetch Wheel Tester results."
+        )
+        debug_info["wheel_tester_check"] = {"status": "fetch_error"}
+        # Wheel Tester 결과 없으면 PyPI 결과가 최종
 
     # --- 최종 결과 정리 ---
-    # 소스 컴파일이 필요할 수 있다는 정보 추가 (PyPI가 partial이거나, 둘 다 unknown일 때)
+    # 소스 컴파일이 필요할 수 있다는 정보 추가 (최종 결과가 partial일 때)
     if final_compatibility == "partial":
         final_reason = (
             final_reason.rstrip(".")
             + ". Source compilation might be required on ARM64."
         )
+    # 최종 결과가 unknown일 때 메시지 정리
     elif final_compatibility == "unknown":
         final_reason = f"Could not determine compatibility from PyPI or Wheel Tester ({final_reason}). Manual check recommended."
 
+    # ***** PyPI 경고(Yanked 등)를 최종 reason에 추가 *****
+    if pypi_warning:
+        final_reason = f"{final_reason.rstrip('.')} (Warning: {pypi_warning})"
+
     return {
-        "dependency": original_line or clean_name,
-        "name": clean_name,
+        "dependency": original_line
+        or package_name,  # Use original name/line for display
+        "name": package_name,  # Keep original name
         "version_spec": version_spec,
         "compatible": final_compatibility,
-        "reason": final_reason,
+        "reason": final_reason,  # 최종적으로 경고가 포함될 수 있는 reason
         "direct": direct,
         "parent": parent,
         "debug_info": debug_info,


### PR DESCRIPTION
직접 package 이름과 버전을 처리하는대신 python의 기본 packaging을 사용하고, 올바른 버전 추정 알고리즘을 적용하여 이제 전체 버전 목록을 가져와 명시된 버전 범위를 검색하여 처리합니다.

즉 tensorlfow_cpu라고 requirements.txt에 적혀있어서 pypi에서는 tensorlfow-cpu가 아니기 때문에 검색이 안되서 unknown이라고 뜨는 버그가 없어졌고,
requests<=3.0 과 같이 <=. >=, ==와 같은 경우를 올바르게 처리합니다.
